### PR TITLE
Correct CFBundleVersion in Bluebird_Info.plist

### DIFF
--- a/Bluebird.xcodeproj/Bluebird_Info.plist
+++ b/Bluebird.xcodeproj/Bluebird_Info.plist
@@ -18,7 +18,7 @@
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <string>1.0</string>
   <key>NSPrincipalClass</key>
   <string></string>
 </dict>


### PR DESCRIPTION
This fixes https://github.com/AndrewBarba/Bluebird.swift/issues/6, which was causing an ITMS error when Carthage referenced `Bluebird.framework` is copied into `App.app/Frameworks/Bluebird.framework` due to having a missing `CFBundleVersion` key.

It was previously missing because it referenced an un-set `CURRENT_PROJECT_VERSION` build setting.

**Testing:**
```bash
$ carthage build --no-skip-current
*** xcodebuild output can be found in /var/folders/4y/7k0ckw7n69v9bgsvt6x7bnrc0000gn/T/carthage-xcodebuild.AEJZJ5.log
*** Building scheme "Bluebird-Package" in Bluebird.xcodeproj

$ plutil -convert xml1 Carthage/Build/iOS/Bluebird.framework/Info.plist -o ~/Desktop/Bluebird_Info.plist

$ grep "CFBundleVersion" ~/Desktop/Bluebird_Info.plist
	<key>CFBundleVersion</key>

$
```

**Built inside app using this branch:**
|Framework Bundle|Info.plist|
|---|---|
|![Screen Shot 2020-04-01 at 12 13 05 PM](https://user-images.githubusercontent.com/5728070/78172010-8eaa9a00-7412-11ea-8b33-c11e9c242274.png)|![Screen Shot 2020-04-01 at 12 13 13 PM](https://user-images.githubusercontent.com/5728070/78172013-8fdbc700-7412-11ea-893a-6ba60fa09a20.png)|

Fixes #6.