### PR TITLE
Support async/await

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Bluebird",
     products: [
-        .library(name: "Bluebird", targets: ["Bluebird"]),
+        .library(name: "Bluebird", targets: ["Bluebird"])
     ],
     targets: [
         .target(

--- a/Sources/Promise+Async.swift
+++ b/Sources/Promise+Async.swift
@@ -1,0 +1,23 @@
+//
+//  Promise+Async.swift
+//  
+//
+//  Created by Andrew Barba on 6/8/21.
+//
+
+import Foundation
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension Promise {
+
+    /// Retrieve the value of the promise using async/await in Swift 5.5
+    ///
+    /// - Returns: Result
+    public func value() async throws -> Result {
+        return try await withUnsafeThrowingContinuation { promise in
+            self
+                .then { promise.resume(returning: $0) }
+                .catch { promise.resume(throwing: $0) }
+        }
+    }
+}

--- a/Sources/Promise+Async.swift
+++ b/Sources/Promise+Async.swift
@@ -13,11 +13,11 @@ extension Promise {
     /// Retrieve the value of the promise using async/await in Swift 5.5
     ///
     /// - Returns: Result
-    public func value() async throws -> Result {
+    public func value(on queue: DispatchQueue = .main) async throws -> Result {
         return try await withUnsafeThrowingContinuation { promise in
             self
-                .then { promise.resume(returning: $0) }
-                .catch { promise.resume(throwing: $0) }
+                .then(on: queue) { promise.resume(returning: $0) }
+                .catch(on: queue) { promise.resume(throwing: $0) }
         }
     }
 }

--- a/Sources/Promise+Async.swift
+++ b/Sources/Promise+Async.swift
@@ -20,4 +20,21 @@ extension Promise {
                 .catch(on: queue) { promise.resume(throwing: $0) }
         }
     }
+
+
+    /// Initialize a promise with an async handler
+    /// 
+    /// - Parameter resolver: Async resolver
+    public convenience init(_ resolver: @escaping () async throws -> Result) {
+        self.init { resolve, reject in
+            async {
+                do {
+                    let value = try await resolver()
+                    resolve(value)
+                } catch {
+                    reject(error)
+                }
+            }
+        }
+    }
 }

--- a/Tests/BluebirdTests.swift
+++ b/Tests/BluebirdTests.swift
@@ -744,4 +744,12 @@ class BluebirdTests: XCTestCase {
         }
         waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
+
+    // MARK: - Async/Await
+
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    func testAsyncAwait() async throws {
+        let result = try await getInt(5).value()
+        XCTAssertEqual(result, 5)
+    }
 }

--- a/Tests/BluebirdTests.swift
+++ b/Tests/BluebirdTests.swift
@@ -486,16 +486,16 @@ class BluebirdTests: XCTestCase {
         let exp = expectation(description: "Promise.map.concurrent")
         let arr = [1, 10, 5, 6, 8, 94, 4]
         map(arr) { getInt($0) }
-            .then { results in
-                XCTAssertEqual(results.count, arr.count)
-                for (index, result) in results.enumerated() {
-                    XCTAssertEqual(result, arr[index])
-                }
-                exp.fulfill()
+        .then { results in
+            XCTAssertEqual(results.count, arr.count)
+            for (index, result) in results.enumerated() {
+                XCTAssertEqual(result, arr[index])
             }
-            .catch { _ in
-                XCTFail()
-            }
+            exp.fulfill()
+        }
+        .catch { _ in
+            XCTFail()
+        }
         waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
@@ -503,16 +503,16 @@ class BluebirdTests: XCTestCase {
         let exp = expectation(description: "Promise.map.series")
         let arr = [1, 10, 5, 6, 8, 94, 4]
         mapSeries(arr) { getInt($0) }
-            .then { results in
-                XCTAssertEqual(results.count, arr.count)
-                for (index, result) in results.enumerated() {
-                    XCTAssertEqual(result, arr[index])
-                }
-                exp.fulfill()
+        .then { results in
+            XCTAssertEqual(results.count, arr.count)
+            for (index, result) in results.enumerated() {
+                XCTAssertEqual(result, arr[index])
             }
-            .catch { _ in
-                XCTFail()
-            }
+            exp.fulfill()
+        }
+        .catch { _ in
+            XCTFail()
+        }
         waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
@@ -520,17 +520,17 @@ class BluebirdTests: XCTestCase {
         let exp = expectation(description: "Promise.map.chain.concurrent")
         let arr = [1, 10, 5, 6, 8, 94, 4]
         map(arr) { getInt($0) }
-            .map { getInt($0 + 1) }
-            .then { results in
-                XCTAssertEqual(results.count, arr.count)
-                for (index, result) in results.enumerated() {
-                    XCTAssertEqual(result, arr[index] + 1)
-                }
-                exp.fulfill()
+        .map { getInt($0 + 1) }
+        .then { results in
+            XCTAssertEqual(results.count, arr.count)
+            for (index, result) in results.enumerated() {
+                XCTAssertEqual(result, arr[index] + 1)
             }
-            .catch { _ in
-                XCTFail()
-            }
+            exp.fulfill()
+        }
+        .catch { _ in
+            XCTFail()
+        }
         waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
@@ -538,17 +538,17 @@ class BluebirdTests: XCTestCase {
         let exp = expectation(description: "Promise.map.chain.series")
         let arr = [1, 10, 5, 6, 8, 94, 4]
         mapSeries(arr) { getInt($0) }
-            .mapSeries { getInt($0 + 1) }
-            .then { results in
-                XCTAssertEqual(results.count, arr.count)
-                for (index, result) in results.enumerated() {
-                    XCTAssertEqual(result, arr[index] + 1)
-                }
-                exp.fulfill()
+        .mapSeries { getInt($0 + 1) }
+        .then { results in
+            XCTAssertEqual(results.count, arr.count)
+            for (index, result) in results.enumerated() {
+                XCTAssertEqual(result, arr[index] + 1)
             }
-            .catch { _ in
-                XCTFail()
-            }
+            exp.fulfill()
+        }
+        .catch { _ in
+            XCTFail()
+        }
         waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
@@ -656,7 +656,7 @@ class BluebirdTests: XCTestCase {
             }
             .catch { error in
                 XCTFail()
-        }
+            }
         waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 
@@ -748,8 +748,24 @@ class BluebirdTests: XCTestCase {
     // MARK: - Async/Await
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-    func testAsyncAwait() async throws {
+    func testAsyncAwaitValue() async throws {
         let result = try await getInt(5).value()
         XCTAssertEqual(result, 5)
+    }
+
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    func testAsyncAwaitInit() async throws {
+        let exp = expectation(description: "Promise.async.init")
+        let promise: Promise<Int> = Promise {
+            return try await getInt(5).value()
+        }
+        promise.then { result in
+            XCTAssertEqual(result, 8)
+            exp.fulfill()
+        }
+        .catch { _ in
+            XCTFail()
+        }
+        waitForExpectations(timeout: defaultTimeout, handler: nil)
     }
 }


### PR DESCRIPTION
- Supports async/await in Swift 5.5 via a new `value() async` method on the promise
- Initialize a `Promise` with an async handler

#### Async Value

```swift
let user = await getUser().value()
```

#### Async Init

```swift
let promise = Promise<User> {
    return await getUserAsync()
}
```

#### Async chain

```swift
getUser()
    .then { await getFavorites(for: $0) }
```